### PR TITLE
Add no_debug_info to erl_opts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
-{erl_opts, []}.
+{erl_opts, [no_debug_info]}.
 {deps, []}.


### PR DESCRIPTION
This lowers the file size of all beam files from ~1400kb to ~250kb. I don't think including the abstract code for this dependency is very useful.

I would also suggest moving the .pem files from priv so they are not included in releases or are they needed even though the beams should include all the data? (I can make this change in a separate PR)
