### PR TITLE
Revert "Add no_debug_info to erl_opts"

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
-{erl_opts, [no_debug_info]}.
+{erl_opts, []}.
 {deps, []}.


### PR DESCRIPTION
This reverts commit e4993a6588cf000473587a8e0916e9e7f698b692.

It breaks dialyzer, and won't rebar already take care of turning off debug info if the user requests it?