### PR TITLE
Allow rebar3 compilation on Windows

### DIFF
--- a/certs_spec/win_gen_certifi_mod.escript
+++ b/certs_spec/win_gen_certifi_mod.escript
@@ -1,0 +1,23 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+-module(compile).
+
+-define(CERTS_MOD, "certifi_cacerts").
+
+
+build_module(Mod, Certs) ->
+    Pems = public_key:pem_decode(Certs),
+    Cacerts = [Der || {'Certificate', Der, _} <- Pems],
+    Src = ["-module(", Mod, ").\n",
+           "-compile([compressed, no_line_info]).\n",
+           "-export([ders/0]).\n\n",
+           "ders() ->", io_lib:format("~n    ~p.~n", [Cacerts])],
+    OutputPath = filename:join(["src", Mod ++ ".erl"]),
+    ok = file:write_file(OutputPath, Src),
+    ok.
+
+main(_) ->
+  {ok, Cacerts} = file:read_file("certs_spec/cacerts.pem"),
+  ok = build_module(?CERTS_MOD, Cacerts),
+  ok.
+

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {erl_opts, []}.
 
 {pre_hooks, [{"(linux|darwin|solaris)", compile, "make -C certs_spec all"},
+             {"(win32|win64)", compile, "escript certs_spec/win_gen_certifi_mod.escript"},
              {"(freebsd|openbsd)", compile, "gmake -C certs_spec all"}]}.


### PR DESCRIPTION
Since we can't assume (for rebar3 at least) that Make or gmake is
available, we instead offload the work to an escript.

The escript is a copy of the existing certs_spec/gen_certifi_mod.escript
but runs relative to the library's own root instead in order to yield
predictable results, the expected context for a rebar3 hook.

Should fix #14 in a portable manner, and once on hex could allow
rebar3 to update its set of root certs.