### PR TITLE
erlangmk: mention dep version number in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [parse_trans  %% Only compile-time
+{deps, [{parse_trans, "3.2.0"}  %% Only compile-time
        ]}.
 {erl_opts, [deterministic  %% Added since OTP 20
            ,{platform_define, "^2", 'OTP_20_AND_ABOVE'}


### PR DESCRIPTION
Fixes https://github.com/benoitc/hackney/issues/484
Turns out if a version is not specified (note that package is also not present in erlang.mk's list) then erlang.mk will fail to build certifi as a dep.
cc @essen
