### PR TITLE
[WIP] nowmix: use a Mix-pleasing version constraint format

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{parse_trans, "3.2.0"}  %% Only compile-time
+{deps, [{parse_trans, "~>3.2"}  %% Only compile-time
        ]}.
 {erl_opts, [deterministic  %% Added since OTP 20
            ,{platform_define, "^2", 'OTP_20_AND_ABOVE'}


### PR DESCRIPTION
Continuation of https://github.com/certifi/erlang-certifi/pull/25
which itself is a solution to https://github.com/benoitc/hackney/issues/484
Discussion from https://github.com/certifi/erlang-certifi/pull/25#issuecomment-369590347
So this PR is looking to please rebar3, Mix & erlang.mk dependency handling.

It seems the `~>X.Y.Z` or `~>X.Y` format pleases both Mix and rebar3. However erlang.mk does not like this format.
@essen Do you think it would be reasonable for erlang.mk to support `~>X.Y.Z` as if it was just `X.Y.Z`? I am not even sure that is acceptable by Mix!
Otherwise I don't see an easy fix to this issue and that makes using BEAM libs across languages not easy, at least if erlang.mk is concerned.

Note: **erlang.mk fails to build with**

```
make[1]: Leaving directory '/home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/rebar'
/home/pete/wefwefwef/erlang-certifi.git/bla
rm -f /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/deps.log
rm -f /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/apps.log
mkdir -p /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk
set -e; for dep in  ; do \
	mkdir -p $dep/ebin; \
done
set -e; for dep in  ; do \
	if grep -qs ^$dep$ /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/apps.log; then \
		:; \
	else \
		echo $dep >> /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/apps.log; \
		make -C $dep IS_APP=1; \
	fi \
done
mkdir -p /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk
set -e; for dep in /home/pete/wefwefwef/erlang-certifi.git/bla/deps/certifi ; do \
	if grep -qs ^$dep$ /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/deps.log; then \
		:; \
	else \
		echo $dep >> /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/deps.log; \
		if [ -f $dep/GNUmakefile ] || [ -f $dep/makefile ] || [ -f $dep/Makefile ]; then \
			make -C $dep IS_DEP=1; \
		else \
			echo "Error: No Makefile to build dependency $dep." >&2; \
			exit 2; \
		fi \
	fi \
done
make[1]: Entering directory '/home/pete/wefwefwef/erlang-certifi.git/bla/deps/certifi'
if test -d /home/pete/wefwefwef/erlang-certifi.git/bla/apps/parse_trans; then echo "Error: Dependency" "parse_trans (parse_trans)" "conflicts with application found in /home/pete/wefwefwef/erlang-certifi.git/bla/apps/parse_trans." >&2; exit 17; fi
mkdir -p /home/pete/wefwefwef/erlang-certifi.git/bla/deps
mkdir -p /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/hex /home/pete/wefwefwef/erlang-certifi.git/bla/deps/parse_trans; curl -Lfo /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/hex/parse_trans.tar  https://repo.hex.pm/tarballs/parse_trans-~>3.2.0.tar; tar -xOf /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/hex/parse_trans.tar contents.tar.gz | tar -C /home/pete/wefwefwef/erlang-certifi.git/bla/deps/parse_trans -xzf -;
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 403 Forbidden
tar: /home/pete/wefwefwef/erlang-certifi.git/bla/.erlang.mk/hex/parse_trans.tar: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
/home/pete/wefwefwef/erlang-certifi.git/bla/erlang.mk:4813: recipe for target '/home/pete/wefwefwef/erlang-certifi.git/bla/deps/parse_trans' failed
make[1]: *** [/home/pete/wefwefwef/erlang-certifi.git/bla/deps/parse_trans] Error 2
make[1]: Leaving directory '/home/pete/wefwefwef/erlang-certifi.git/bla/deps/certifi'
erlang.mk:4311: recipe for target 'deps' failed
make: *** [deps] Error 2
```

```make
PROJECT = bla
DEPS = certifi
dep_certifi = git http://github.com/fenollp/erlang-certifi nowmix
include erlang.mk
```

cc @ericmj
cc `top @github/erlang/rebar3`: @tsloughter @tuncer @ferd
