### PR TITLE
Automatic updates at run time

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
-{deps, [{parse_trans, "~>3.3"}  %% Only compile-time
+{deps, [{parse_trans, "~>3.3"}, %% Only compile-time
+        {ssl_verify_fun, "1.1.4"}
        ]}.
 {erl_opts, [deterministic  %% Added since OTP 20
            ,{platform_define, "^2", 'OTP_20_AND_ABOVE'}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,8 @@
 {"1.1.0",
-[{<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},0}]}.
+[{<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},0},
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.4">>},0}]}.
 [
 {pkg_hash,[
- {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>}]}
+ {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
+ {<<"ssl_verify_fun">>, <<"F0EAFFF810D2041E93F915EF59899C923F4568F4585904D010387ED74988E77B">>}]}
 ].

--- a/src/certifi.app.src
+++ b/src/certifi.app.src
@@ -2,8 +2,23 @@
  [{description, "CA bundle adapted from Mozilla by https://certifi.io"},
   {vsn, "2.5.1"},
   {registered, []},
-  {applications, [kernel,stdlib]},
-  {env,[]},
+  {mod, {certifi_app, []}},
+  {applications,
+   [kernel,
+    stdlib,
+    compiler,
+    crypto,
+    inets,
+    public_key,
+    ssl,
+    %% External dependencies
+    parse_trans,
+    ssl_verify_fun
+   ]},
+  {env,
+   [{auto_update_interval, 3600}, % in seconds
+    {auto_update_url, "https://curl.haxx.se/ca/cacert.pem"}
+   ]},
   {modules, []},
 
   {maintainers, ["Benoit Chesneau"]},

--- a/src/certifi.erl
+++ b/src/certifi.erl
@@ -2,23 +2,15 @@
 -compile({parse_transform, ct_expand}).
 
 -export([cacertfile/0,
-         cacerts/0]).
+         cacerts/0
+        ]).
 
 
 %% @doc CACertFile gives the path to the file with an X.509 certificate list
 %% containing the Mozilla CA Certificate that can then be used via the
 %% cacertfile setting in ssl options passed to the connect function.
 cacertfile() ->
-  PrivDir = case code:priv_dir(certifi) of
-              {error, _} ->
-                %% try to get relative priv dir. useful for tests.
-                AppDir = filename:dirname(
-                           filename:dirname(code:which(?MODULE))
-                          ),
-                filename:join(AppDir, "priv");
-              Dir -> Dir
-            end,
-  filename:join(PrivDir, "cacerts.pem").
+    ct_expand:term( certifi_db:cacertfile() ).
 
 %% @doc CACerts builds an X.509 certificate list containing the Mozilla CA
 %% Certificate that can then be used via the cacerts setting in ssl options
@@ -27,7 +19,7 @@ cacertfile() ->
 cacerts() ->
     ct_expand:term(
       lists:reverse(
-        [Der || {ok,Bin} <- [file:read_file(cacertfile())],
+        [Der || {ok,Bin} <- [file:read_file(certifi_db:cacertfile())],
                 {'Certificate',Der,_} <- public_key:pem_decode(Bin)
         ]
        )

--- a/src/certifi_app.erl
+++ b/src/certifi_app.erl
@@ -1,0 +1,24 @@
+%% @private
+-module(certifi_app).
+-behaviour(application).
+
+%% ------------------------------------------------------------------
+%% application Function Exports
+%% ------------------------------------------------------------------
+
+-export(
+   [start/2,
+    stop/1
+   ]).
+
+%% ------------------------------------------------------------------
+%% application Function Definitions
+%% ------------------------------------------------------------------
+
+-spec start(term(), list()) -> {ok, pid()}.
+start(_StartType, _StartArgs) ->
+    certifi_sup:start_link().
+
+-spec stop(term()) -> ok.
+stop(_State) ->
+    ok.

--- a/src/certifi_db.erl
+++ b/src/certifi_db.erl
@@ -1,0 +1,224 @@
+%% @private
+-module(certifi_db).
+-behaviour(gen_server).
+
+-compile({parse_transform, ct_expand}).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export(
+   [start_link/0,
+    cacertfile/0
+   ]).
+
+-ignore_xref(
+   [start_link/0
+   ]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+
+-export(
+   [init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+   ]).
+
+%% ------------------------------------------------------------------
+%% Macro Definitions
+%% ------------------------------------------------------------------
+
+-define(SERVER, ?MODULE).
+-define(TABLE, ?MODULE).
+
+%% ------------------------------------------------------------------
+%% Record and Type Definitions
+%% ------------------------------------------------------------------
+
+-record(state, {
+         }).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+cacertfile() ->
+    try ets:lookup(?TABLE, cacert_filepath) of
+        [{_, CacertFilePath}] ->
+            CacertFilePath;
+        [] ->
+            % not updated yet
+            bundled_cacertfile()
+    catch
+        error:badarg ->
+            % not runnign yet (probably compiling)
+            bundled_cacertfile()
+    end.
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+
+init([]) ->
+    _ = create_table(),
+    _ = schedule_auto_update(now),
+    {ok, #state{
+           }}.
+
+handle_call(_Call, _From, State) ->
+    {stop, unexpected_call, State}.
+
+handle_cast(_Cast, State) ->
+    {stop, unexpected_cast, State}.
+
+handle_info(try_updating, State) ->
+    {ok, Url} = application:get_env(certifi, auto_update_url),
+    {ok, SslOpts} = certifi_https:secure_ssl_opts(Url),
+    Method = get,
+    Headers = [{"accept", "application/x-pem-file"}],
+    Request = {Url, Headers},
+    Timeout = timer:seconds(10),
+    HttpOptions = [{ssl, SslOpts}, {timeout, Timeout}],
+    OutputFilePath = generate_update_filepath(),
+    ok = filelib:ensure_dir(OutputFilePath),
+    Options = [{stream, OutputFilePath}],
+    _ = case httpc:request(Method, Request, HttpOptions, Options) of
+            {ok, saved_to_file} ->
+                io:format("updated (~p)~n", [OutputFilePath]),
+                ets:insert(?TABLE, {cacert_filepath, OutputFilePath}),
+                recompile_certifi_module();
+            {error, Reason} ->
+                io:format("failed to update: ~p~n", [Reason])
+        end,
+    schedule_auto_update(later),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {stop, unexpected_info, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions - certifi Module Regeneration
+%% ------------------------------------------------------------------
+
+create_table() ->
+    TableOpts = [named_table, protected, {read_concurrency,true}],
+    ets:new(?TABLE, TableOpts).
+
+certifi_module_source() ->
+    ct_expand:term(
+      (fun () ->
+               LibDir = code:lib_dir(certifi),
+               ModulePath = filename:join([LibDir, "src", "certifi.erl"]),
+               {ok, ModuleSource} = file:read_file(ModulePath),
+               ModuleSource
+       end)()).
+
+certifi_compile_options() ->
+    Info = certifi:module_info(compile),
+    AllOptions = proplists:get_value(options, Info, []),
+    FilteredOptions =
+        lists:filter(
+          fun ({K, _V}) when is_atom(K) ->
+                  not lists:member(K, [i, outdir]);
+              (K) when is_atom(K) ->
+                  true
+          end,
+          AllOptions),
+    %%
+    [{parse_transform, ct_expand} | FilteredOptions].
+
+bundled_cacertfile() ->
+  PrivDir = case code:priv_dir(certifi) of
+              {error, _} ->
+                %% try to get relative priv dir. useful for tests.
+                AppDir = filename:dirname(
+                           filename:dirname(code:which(?MODULE))
+                          ),
+                filename:join(AppDir, "priv");
+              Dir -> Dir
+            end,
+  filename:join(PrivDir, "cacerts.pem").
+
+recompile_certifi_module() ->
+    ModuleSource = certifi_module_source(),
+    CompileOptions = certifi_compile_options(),
+
+    % based on: https://stackoverflow.com/a/2160696
+    %
+    % create token groups
+    ModuleSourceStr = unicode:characters_to_list(ModuleSource),
+    {ok, TokenList, _} = erl_scan:string(ModuleSourceStr),
+    TokenGroups =
+        lists_split_on(
+          fun ({dot, _Line}) -> true;
+              (_) -> false
+          end,
+          TokenList),
+
+    % create form groups
+    FormsGroups =
+        lists:map(
+          fun (TokenGroup) ->
+                  {ok, FormsGroup} = erl_parse:parse_form(TokenGroup),
+                  FormsGroup
+          end,
+          TokenGroups),
+
+    % compile form groups to binary
+    {ok, certifi, ByteCode} = compile:forms(FormsGroups, CompileOptions),
+
+    % load module from binary
+    {module, certifi} = code:load_binary(certifi, "nofile", ByteCode).
+
+lists_split_on(Fun, List) ->
+    lists_split_on_recur(Fun, List, [], []).
+
+lists_split_on_recur(Fun, [H|T], GroupAcc, GroupsAcc) ->
+    case Fun(H) of
+        true ->
+            OrderedGroupAcc = lists:reverse([H | GroupAcc]),
+            lists_split_on_recur(Fun, T, [], [OrderedGroupAcc | GroupsAcc]);
+        false ->
+            lists_split_on_recur(Fun, T, [H | GroupAcc], GroupsAcc)
+    end;
+lists_split_on_recur(_Fun, [], GroupAcc, GroupsAcc) ->
+    OrderedGroupAcc = lists:reverse(GroupAcc),
+    lists:foldl(
+      fun ([], Acc) ->
+              Acc;
+          (Group, Acc) ->
+              [Group | Acc]
+      end,
+      [],
+      [OrderedGroupAcc | GroupsAcc]).
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions - Auto Updating
+%% ------------------------------------------------------------------
+
+schedule_auto_update(now) ->
+    self() ! try_updating;
+schedule_auto_update(later) ->
+    {ok, Interval} = application:get_env(certifi, auto_update_interval),
+    IntervalMs = timer:seconds(Interval),
+    erlang:send_after(IntervalMs, self(), try_updating).
+
+generate_update_filepath() ->
+    <<RandomUint128:128/integer>> = crypto:strong_rand_bytes(16),
+    Filename = "cacerts." ++ integer_to_list(RandomUint128, 36) ++ ".pem",
+    Directory = filename:basedir(user_cache, "certifi"),
+    filename:join(Directory, Filename).

--- a/src/certifi_https.erl
+++ b/src/certifi_https.erl
@@ -1,0 +1,93 @@
+%% @private
+-module(certifi_https).
+
+-include_lib("public_key/include/OTP-PUB-KEY.hrl").
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export(
+   [secure_ssl_opts/1,
+    partial_chain/1
+   ]).
+
+-spec secure_ssl_opts(string())
+        -> {ok, [ssl:option(), ...]} | {error, term()}.
+secure_ssl_opts(Url) ->
+    try http_uri:parse(Url) of
+        {ok, {https, _UserInfo, Host, _Port, _Path, _Query}} ->
+            Opts = host_ssl_opts(Host),
+            {ok, Opts};
+        {ok, {https, _UserInfo, Host, _Port, _Path, _Query, _Fragment}} ->
+            Opts = host_ssl_opts(Host),
+            {ok, Opts};
+        %%
+        {ok, {http, _UserInfo, _Host, _Port, _Path, _Query}} ->
+            {error, insecure_transport};
+        {ok, {http, _UserInfo, _Host, _Port, _Path, _Query, _Fragment}} ->
+            {error, insecure_transport};
+        {error, Reason} ->
+            {error, Reason}
+    catch
+        Class:Reason ->
+            {error, {bad_uri, {Class, Reason}}}
+    end.
+
+-spec partial_chain([public_key:der_encoded()])
+        -> {trusted_ca, #'Certificate'{}} | unknown_ca.
+partial_chain(Certs) ->
+    % Taken from hackney, licensed under Apache 2 license,
+    % which in turn took it from rebar3, licensed under BSD.
+    Certs1 = lists:reverse([{Cert, public_key:pkix_decode_cert(Cert, otp)} ||
+                            Cert <- Certs]),
+    CACerts = certifi:cacerts(),
+    CACerts1 = [public_key:pkix_decode_cert(Cert, otp) || Cert <- CACerts],
+
+    case lists_anymap(
+           fun ({_, Cert}) ->
+                   check_cert(CACerts1, Cert)
+           end,
+           Certs1)
+    of
+        {true, Trusted} ->
+            {trusted_ca, element(1, Trusted)};
+        false ->
+            unknown_ca
+    end.
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+host_ssl_opts(Host) ->
+    % Taken from hackney, licensed under Apache 2 license.
+    CACerts = certifi:cacerts(),
+    VerifyFun =
+        {fun ssl_verify_hostname:verify_fun/3,
+         [{check_hostname, Host}]
+        },
+    [{verify, verify_peer},
+     {depth, 99},
+     {cacerts, CACerts},
+     {partial_chain, fun ?MODULE:partial_chain/1},
+     {verify_fun, VerifyFun}].
+
+check_cert(CACerts, Cert) ->
+    % Taken from hackney, licensed under Apache 2 license.
+    CertPKI = extract_public_key_info(Cert),
+    lists:any(
+      fun(CACert) ->
+              extract_public_key_info(CACert) =:= CertPKI
+      end, CACerts).
+
+extract_public_key_info(Cert) ->
+    ((Cert#'OTPCertificate'.tbsCertificate)#'OTPTBSCertificate'.subjectPublicKeyInfo).
+
+lists_anymap(Fun, [H|T]) ->
+    case Fun(H) of
+        true -> {true, H};
+        false -> lists_anymap(Fun, T)
+    end;
+lists_anymap(_Fun, []) ->
+    false.

--- a/src/certifi_sup.erl
+++ b/src/certifi_sup.erl
@@ -1,0 +1,45 @@
+%% @private
+-module(certifi_sup).
+-behaviour(supervisor).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export([start_link/0]).
+
+%% ------------------------------------------------------------------
+%% supervisor Function Exports
+%% ------------------------------------------------------------------
+
+-export([init/1]).
+
+%% ------------------------------------------------------------------
+%% Macro Definitions
+%% ------------------------------------------------------------------
+
+-define(SERVER, ?MODULE).
+
+-define(CHILD_SPEC(Module, Type),
+        {Module,                   % id
+         {Module, start_link, []}, % start
+         permanent,                % restart
+         5000,                     % shutdown
+         Type,
+         [Module]}).               % modules
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%% ------------------------------------------------------------------
+%% supervisor Function Definitions
+%% ------------------------------------------------------------------
+
+init([]) ->
+    SupFlags = {one_for_one, 0, 1},
+    ChildSpecs = [?CHILD_SPEC(certifi_db, worker)],
+    {ok, {SupFlags, ChildSpecs}}.


### PR DESCRIPTION
**This is only a proof of concept for now**, as I would like to get some input on whether this is actually feasible.

Main points:
- an updater process is launched under the app supervisor
- this process will regularly download, from a HTTPS URL, updated versions 
  of the CA bundle onto a file in an user cache OS directory
- in case of success, the `certifi` module will then be recompiled so that it 
  loads and exposes the new bundle while still enjoying the performance 
  benefits brought out by the `ct_expand` parse transform.

Tricky bits:
- because the download must be secure itself, `ssl_verify_fun` must be imported
  as a dependency and the usual CA verification boilerplate enforced;
- for this, the latest loaded CA list is used; there's the unlikely possibility that
  a very outdated version of `certifi` tries to update using a HTTPS
  URL whose certificate was signed by a CA still not listed on the bundled list,
  and therefore be put in a chicken-and-egg sort of situation;
- recompiling modules in runtime with parse transforms _is_ a bit obscene

To do (in case this goes ahead):
- conditional HTTPS requests (no sense in downloading the same bundle over and over)
- gracefully dealing with expectable failures