### PR TITLE
Prevent silent error when reading certificates file

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -32,5 +32,6 @@ jobs:
           fetch-depth: 0
       - run: rebar3 --version
       - run: rebar3 eunit
+      - run: rebar3 dialyzer
       - shell: bash
         run: '[[ 0 -eq $(git --no-pager diff | wc -l) ]]'

--- a/src/certifi.erl
+++ b/src/certifi.erl
@@ -26,9 +26,13 @@ cacertfile() ->
 -spec cacerts() -> [binary(),...].
 cacerts() ->
     ct_expand:term(
-      lists:reverse(
-        [Der || {ok,Bin} <- [file:read_file(cacertfile())],
-                {'Certificate',Der,_} <- public_key:pem_decode(Bin)
-        ]
+      lists:foldl(
+        fun ({'Certificate', Der, _}, Acc) ->
+                [Der | Acc]
+        end,
+        [],
+        (fun ({ok, Bin}) ->
+                 public_key:pem_decode(Bin)
+         end)(file:read_file(cacertfile()))
        )
      ).


### PR DESCRIPTION
Ensure that, if reading the certificates file fails, compilation of `certifi.erl` also fails.

Pattern matching within list comprehensions was the cause of the issue this PR intends on fixing, since failed patterns are silently ignored.